### PR TITLE
Hack to get imagesnap working on high sierra

### DIFF
--- a/ImageSnap.m
+++ b/ImageSnap.m
@@ -130,6 +130,7 @@ NSString *const VERSION = @"0.2.5";
 
     } else {
         [self takeSnapshotWithFilename:[self fileNameWithSequenceNumber:0]];                // Capture a frame
+            [[NSRunLoop currentRunLoop] runUntilDate:[[NSDate date] dateByAddingTimeInterval:1]];
     }
 
     [self stopSession];


### PR DESCRIPTION
Addresses this [issue](https://github.com/rharder/imagesnap/issues/16).

I am not completely sure why this runloop is necessary, but it does seem to fix the issue.