### PR TITLE
feat: accepts path for timelapse mode

### DIFF
--- a/ImageSnap.m
+++ b/ImageSnap.m
@@ -146,7 +146,7 @@ NSString *const VERSION = @"0.2.14";
         NSFileManager *fileManager = [NSFileManager defaultManager];
         for (unsigned long long seq = 0; seq < ULLONG_MAX ; seq++) { // 64 bit counter - a lot of pictures
             
-            fileNameWithSeq = [self fileNameWithSequenceNumber:seq];
+            fileNameWithSeq = [self fileNameWithSequenceNumber:seq withPath:path];
             if(![fileManager fileExistsAtPath:fileNameWithSeq]){
                 
                 // capture and write
@@ -257,12 +257,12 @@ NSString *const VERSION = @"0.2.14";
     }
 }
 
-- (NSString *)fileNameWithSequenceNumber:(unsigned long)sequenceNumber {
+- (NSString *)fileNameWithSequenceNumber:(unsigned long)sequenceNumber withPath:(NSString*)path {
     
     //    NSDate *now = [NSDate date];
     //    NSString *nowstr = [self.dateFormatter stringFromDate:now];
     //    return [NSString stringWithFormat:@"snapshot-%05lu-%s.jpg", sequenceNumber, nowstr.UTF8String];
-    return [NSString stringWithFormat:@"snapshot-%05lu.jpg", sequenceNumber];
+    return [NSString stringWithFormat:@"%@snapshot-%05lu.jpg", path, sequenceNumber];
 }
 
 @end


### PR DESCRIPTION
## Before

If you are using a combination of the single-photo and timelapse options, you may be looking to put the photos in folders.

You can already do this in single-photo mode (when you **don't** supply `-t x.xx`) by supplying path and filename: 

```
imagesnap "photos/snapshot.jpg"
```

## After

This allows you to supply the path in timelapse mode as well (when you **do** supply `-t x.xx`). 

(Assuming dir "photos" already exists):

```
imagesnap -t 2.5 "photos/"
```

Which outputs:
```
Capturing image from device "FaceTime HD Camera (Built-in)"...
photos/snapshot-00000.jpg
photos/snapshot-00001.jpg
photos/snapshot-00002.jpg
photos/snapshot-00003.jpg
photos/snapshot-00004.jpg
```

Running again without deleting those photos continues the count as expected:
```
Capturing image from device "FaceTime HD Camera (Built-in)"...
photos/snapshot-00005.jpg
photos/snapshot-00006.jpg
photos/snapshot-00007.jpg
```